### PR TITLE
Fixes to TMB jtag and DDD state machine registers 

### DIFF
--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -859,7 +859,7 @@ public:
   inline int  GetReadDDDStateMachineClock1Lock() {return read_ddd_state_machine_clock1_lock_;}
   inline int  GetReadDDDStateMachineClockALCTLock() {return read_ddd_state_machine_clock_alct_lock_;}
   inline int  GetReadDDDStateMachineClockdALCTLock() {return read_ddd_state_machine_clockd_alct_lock_;}
-  inline int  GetReadDDDStateMachineClockCFEBLock() {return read_ddd_state_machine_clock_cfeb_lock_;}
+  inline int  GetReadDDDStateMachineClockMPCLock() {return read_ddd_state_machine_clock_mpc_lock_;}
   inline int  GetReadDDDStateMachineClockDCCLock() {return read_ddd_state_machine_clock_dcc_lock_;}
   inline int  GetReadDDDStateMachineClockRPCLock() {return read_ddd_state_machine_clock_rpc_lock_;}
   //
@@ -2857,7 +2857,7 @@ private:
   int read_ddd_state_machine_clock1_lock_;
   int read_ddd_state_machine_clock_alct_lock_;
   int read_ddd_state_machine_clockd_alct_lock_;
-  int read_ddd_state_machine_clock_cfeb_lock_;
+  int read_ddd_state_machine_clock_mpc_lock_;
   int read_ddd_state_machine_clock_dcc_lock_;
   int read_ddd_state_machine_clock_rpc_lock_;
   //
@@ -3485,13 +3485,14 @@ private:
   //0XD4 = ADR_JTAGSM0:  JTAG State Machine Control (reads JTAG PROM)
   //------------------------------------------------------------------
   int jtag_state_machine_start_;
+  int jtag_state_machine_select_;
   int jtag_state_machine_sreset_;
   int jtag_disable_write_to_adr10_;
   int jtag_state_machine_throttle_;
   //
   int read_jtag_state_machine_start_;
   int read_jtag_state_machine_sreset_;
-  int read_jtag_state_machine_autostart_;
+  int read_jtag_state_machine_select_;
   int read_jtag_state_machine_busy_;
   int read_jtag_state_machine_aborted_;
   int read_jtag_state_machine_cksum_ok_;

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -568,7 +568,7 @@ const int ddd_state_machine_clock0d_lock_expected     =  1 ;
 const int ddd_state_machine_clock1_lock_vmereg        =  vme_dddsm_adr;
 const int ddd_state_machine_clock1_lock_bitlo         = 10;
 const int ddd_state_machine_clock1_lock_bithi         = 10;
-const int ddd_state_machine_clock1_lock_expected      =  0;  
+const int ddd_state_machine_clock1_lock_expected      =  1;
 //
 const int ddd_state_machine_clock_alct_lock_vmereg    =  vme_dddsm_adr;
 const int ddd_state_machine_clock_alct_lock_bitlo     = 11;
@@ -580,20 +580,21 @@ const int ddd_state_machine_clockd_alct_lock_bitlo    = 12;
 const int ddd_state_machine_clockd_alct_lock_bithi    = 12;
 const int ddd_state_machine_clockd_alct_lock_expected =  1;  
 //
-const int ddd_state_machine_clock_cfeb_lock_vmereg     =  vme_dddsm_adr;
-const int ddd_state_machine_clock_cfeb_lock_bitlo      = 13;
-const int ddd_state_machine_clock_cfeb_lock_bithi      = 13;
-const int ddd_state_machine_clock_cfeb_lock_expected   =  0;  
+const int ddd_state_machine_clock_mpc_lock_vmereg     =  vme_dddsm_adr;
+const int ddd_state_machine_clock_mpc_lock_bitlo      = 13;
+const int ddd_state_machine_clock_mpc_lock_bithi      = 13;
+const int ddd_state_machine_clock_mpc_lock_expected   =  1;
 //
 const int ddd_state_machine_clock_dcc_lock_vmereg     =  vme_dddsm_adr;
 const int ddd_state_machine_clock_dcc_lock_bitlo      = 14;
 const int ddd_state_machine_clock_dcc_lock_bithi      = 14;
 const int ddd_state_machine_clock_dcc_lock_expected   =  1;  
 //
+// this is not really the RPC lock. It actually checks if the RPC done bit is somehow a clock
 const int ddd_state_machine_clock_rpc_lock_vmereg     =  vme_dddsm_adr;
 const int ddd_state_machine_clock_rpc_lock_bitlo      = 15;
 const int ddd_state_machine_clock_rpc_lock_bithi      = 15;
-// Expected value for RPC clock lock depends on rpc_exists_ for this TMB...
+const int ddd_state_machine_clock_rpc_lock_expected   = 0;
 //
 //
 //------------------------------------------------------------------
@@ -1949,11 +1950,11 @@ const int jtag_state_machine_sreset_bitlo         =  1;
 const int jtag_state_machine_sreset_bithi         =  1;
 const int jtag_state_machine_sreset_default       =  0;
 //
-// greg, this needs to be changed to allow selection of ALCT userPROM format
-const int jtag_state_machine_autostart_vmereg     =  jtag_sm_ctrl_adr;
-const int jtag_state_machine_autostart_bitlo      =  2;
-const int jtag_state_machine_autostart_bithi      =  2;
-const int jtag_state_machine_autostart_expected   =  1;   //expect JTAG state machine to have auto-started
+const int jtag_state_machine_select_vmereg     =  jtag_sm_ctrl_adr;
+const int jtag_state_machine_select_bitlo      =  2;
+const int jtag_state_machine_select_bithi      =  2;
+const int jtag_state_machine_select_default    =  0;
+const int jtag_state_machine_select_expected   =  0;   //expect old data format
 //
 const int jtag_state_machine_busy_vmereg          =  jtag_sm_ctrl_adr;
 const int jtag_state_machine_busy_bitlo           =  3;

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -6398,6 +6398,7 @@ void TMB::SetTMBRegisterDefaults() {
   //0XD4 = ADR_JTAGSM0:  JTAG State Machine Control (reads JTAG PROM)
   //------------------------------------------------------------------
   jtag_state_machine_start_    = jtag_state_machine_start_default   ;
+  jtag_state_machine_select_   = jtag_state_machine_select_default  ;
   jtag_state_machine_sreset_   = jtag_state_machine_sreset_default  ;
   jtag_disable_write_to_adr10_ = jtag_disable_write_to_adr10_default;
   jtag_state_machine_throttle_ = jtag_state_machine_throttle_default;
@@ -6711,8 +6712,8 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
 								    ddd_state_machine_clock_alct_lock_bithi);
     read_ddd_state_machine_clockd_alct_lock_ = ExtractValueFromData(data,ddd_state_machine_clockd_alct_lock_bitlo,
 								    ddd_state_machine_clockd_alct_lock_bithi);
-    read_ddd_state_machine_clock_cfeb_lock_  = ExtractValueFromData(data,ddd_state_machine_clock_cfeb_lock_bitlo,
-								    ddd_state_machine_clock_cfeb_lock_bithi);
+    read_ddd_state_machine_clock_mpc_lock_  = ExtractValueFromData(data,ddd_state_machine_clock_mpc_lock_bitlo,
+								    ddd_state_machine_clock_mpc_lock_bithi);
     read_ddd_state_machine_clock_dcc_lock_   = ExtractValueFromData(data,ddd_state_machine_clock_dcc_lock_bitlo,
 								    ddd_state_machine_clock_dcc_lock_bithi);
     read_ddd_state_machine_clock_rpc_lock_   = ExtractValueFromData(data,ddd_state_machine_clock_rpc_lock_bitlo,
@@ -7226,7 +7227,7 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
     //------------------------------------------------------------------
     read_jtag_state_machine_start_       = ExtractValueFromData(data,jtag_state_machine_start_bitlo      ,jtag_state_machine_start_bithi      );
     read_jtag_state_machine_sreset_      = ExtractValueFromData(data,jtag_state_machine_sreset_bitlo     ,jtag_state_machine_sreset_bithi     );
-    read_jtag_state_machine_autostart_   = ExtractValueFromData(data,jtag_state_machine_autostart_bitlo  ,jtag_state_machine_autostart_bithi  );
+    read_jtag_state_machine_select_      = ExtractValueFromData(data,jtag_state_machine_select_bitlo     ,jtag_state_machine_select_bithi  );
     read_jtag_state_machine_busy_        = ExtractValueFromData(data,jtag_state_machine_busy_bitlo       ,jtag_state_machine_busy_bithi       );
     read_jtag_state_machine_aborted_     = ExtractValueFromData(data,jtag_state_machine_aborted_bitlo    ,jtag_state_machine_aborted_bithi    );
     read_jtag_state_machine_cksum_ok_    = ExtractValueFromData(data,jtag_state_machine_cksum_ok_bitlo   ,jtag_state_machine_cksum_ok_bithi   );
@@ -7856,7 +7857,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     (*MyOutput_) << "    clock 1 DCM lock = " << std::hex << read_ddd_state_machine_clock1_lock_      << std::endl;
     (*MyOutput_) << "    clock ALCT lock  = " << std::hex << read_ddd_state_machine_clock_alct_lock_  << std::endl;
     (*MyOutput_) << "    clock ALCTd lock = " << std::hex << read_ddd_state_machine_clockd_alct_lock_ << std::endl;
-    (*MyOutput_) << "    clock CFEB lock  = " << std::hex << read_ddd_state_machine_clock_cfeb_lock_  << std::endl;
+    (*MyOutput_) << "    clock MPC lock   = " << std::hex << read_ddd_state_machine_clock_mpc_lock_   << std::endl;
     (*MyOutput_) << "    clock DCC lock   = " << std::hex << read_ddd_state_machine_clock_dcc_lock_   << std::endl;
     (*MyOutput_) << "    clock RPC lock   = " << std::hex << read_ddd_state_machine_clock_rpc_lock_   << std::endl;
     //
@@ -8226,7 +8227,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     (*MyOutput_) << " ->JTAG State Machine Control register:" << std::endl;
     (*MyOutput_) << "    prom start vme   = "   << std::hex << read_jtag_state_machine_start_       << std::endl;
     (*MyOutput_) << "    sreset           = "   << std::hex << read_jtag_state_machine_sreset_      << std::endl;
-    (*MyOutput_) << "    autostart        = "   << std::hex << read_jtag_state_machine_autostart_   << std::endl;
+    (*MyOutput_) << "    alct data format = "   << std::hex << read_jtag_state_machine_select_      << std::endl;
     (*MyOutput_) << "    busy             = "   << std::hex << read_jtag_state_machine_busy_        << std::endl;
     (*MyOutput_) << "    aborted          = "   << std::hex << read_jtag_state_machine_aborted_     << std::endl;
     (*MyOutput_) << "    check sum OK     = "   << std::hex << read_jtag_state_machine_cksum_ok_    << std::endl;
@@ -9119,6 +9120,7 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //------------------------------------------------------------------
     InsertValueIntoDataWord(jtag_state_machine_start_   ,jtag_state_machine_start_bithi   ,jtag_state_machine_start_bitlo   ,&data_word);
     InsertValueIntoDataWord(jtag_state_machine_sreset_  ,jtag_state_machine_sreset_bithi  ,jtag_state_machine_sreset_bitlo  ,&data_word);
+    InsertValueIntoDataWord(jtag_state_machine_select_  ,jtag_state_machine_select_bithi  ,jtag_state_machine_select_bitlo  ,&data_word);
     InsertValueIntoDataWord(jtag_disable_write_to_adr10_,jtag_disable_write_to_adr10_bithi,jtag_disable_write_to_adr10_bitlo,&data_word);
     InsertValueIntoDataWord(jtag_state_machine_throttle_,jtag_state_machine_throttle_bithi,jtag_state_machine_throttle_bitlo,&data_word);
     //
@@ -10110,7 +10112,7 @@ void TMB::CheckJTAGStateMachine() {
   //
   ReadJTAGStateMachine();
   //
-  config_ok &= compareValues("JTAG state machine autostart"         ,read_jtag_state_machine_autostart_  ,jtag_state_machine_autostart_expected  );
+  config_ok &= compareValues("JTAG state machine select"            ,read_jtag_state_machine_select_     ,jtag_state_machine_select_expected     );
   config_ok &= compareValues("JTAG state machine aborted"           ,read_jtag_state_machine_aborted_    ,jtag_state_machine_aborted_expected    );
   config_ok &= compareValues("JTAG state machine check sum OK"      ,read_jtag_state_machine_cksum_ok_   ,jtag_state_machine_cksum_ok_expected   );
   config_ok &= compareValues("JTAG state machine word count OK"     ,read_jtag_state_machine_wdcnt_ok_   ,jtag_state_machine_wdcnt_ok_expected   );
@@ -10141,14 +10143,14 @@ void TMB::CheckDDDStateMachine() {
 			     ,ddd_state_machine_clock_alct_lock_expected );
   config_ok &= compareValues("DDD state machine clock ALCTd lock" ,read_ddd_state_machine_clockd_alct_lock_
 			     ,ddd_state_machine_clockd_alct_lock_expected);
-  config_ok &= compareValues("DDD state machine clock CFEB lock"  ,read_ddd_state_machine_clock_cfeb_lock_
-			     ,ddd_state_machine_clock_cfeb_lock_expected );
+  config_ok &= compareValues("DDD state machine clock MPC lock"   ,read_ddd_state_machine_clock_mpc_lock_
+			     ,ddd_state_machine_clock_mpc_lock_expected );
   config_ok &= compareValues("DDD state machine clock DCC lock"   ,read_ddd_state_machine_clock_dcc_lock_
 			     ,ddd_state_machine_clock_dcc_lock_expected  );
   //
   // expected value of RPC lock check depends on if RPC exists...
   //
-  config_ok &= compareValues("DDD state machine clock RPC lock"   ,read_ddd_state_machine_clock_rpc_lock_,(rpc_exists_ & 0x1)                    );
+  config_ok &= compareValues("DDD state machine clock RPC lock"   ,read_ddd_state_machine_clock_rpc_lock_, ddd_state_machine_clock_rpc_lock_expected);
   //
   ReportCheck("TMB DDD state machine check",config_ok);
   //


### PR DESCRIPTION
Fixes issues in the "TMB State Machine Check" button in the TMB utilities page. 

Updates several outdated definitions / incorrect register definitions, incorrect expected test outcomes, wrong variable names. 

In detail: 

1) the JTAG State Machine autostart check, isn't actually the JTAG state machine autostart. In the firmware it is the "jsm_sel" flag, which switches between old and new JTAG user PROM data formats. The expected value for this is also wrong... it should be 0 rather than 1. 

2) this jsm_sel flag doesn't seem to be set anywhere in the software. The register is written... but always to 0 just by accident.  If this is ever 1 (which it expects) there is something bad happening because 0 is the default in the firmware, and there's no way in the software for this to get set besides somebody manually writing the register in the TMB utils page. 

3) DDD state machine CFEB lock failed isn't actually the CFEB clock. It is the MPC clock. 

4) DDD state machine code is writing to ddd_state_machine_serial_out_, which is a read only register so it doesn't do anything. 

5) The lock status for the DCM and CFEB clocks seems to be backwards. 1 means that the clock is running, 0 means the clock is frozen. We should expect this clocks to run, hence they should be 1. 

6) The RPC lock is also not correct. This signal is actually derived from the RPC done bit, which comes from the RAT FPGA when it is done configuring. It is expected in the software to be 1 if there is an RPC, and 0 if there is no RPC. But really the source of this signal makes no sense. Regardless of whether the rat DONE bit is high or low, this RPC lock signal will always be 0. The only time it becomes 1 is if the DONE bit is toggling. (it is meant to see if a clock is running... if it is always either 0 or 1, it does not look like a running clock). I have no idea what the purpose of this is, but it should be expected to be 0. Otherwise you should always see this check fail unless you have RPC disabled in the software.. (I have the RPC turned off in the xml file here---hence it passes). 
